### PR TITLE
workflowをアップデートに対応させる

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,14 +44,12 @@ jobs:
           make
         env:
           ARCH_NAME: _${{ matrix.arch }}
-      - name: upload artifacts
-        uses: actions/upload-artifact@v2
-        with:
-          name: HISS-${{ steps.tagName.outputs.tag }}.zip
-          path: build/nvda/HISS-${{ steps.tagName.outputs.tag }}.zip
+      - name: generate version info JSON
+        run: |
+          python make_version_info.py
       - name: publish automatic release
         uses: ncipollo/release-action@v1
         with:
-          artifacts: build/nvda/HISS-${{ steps.tagName.outputs.tag }}.zip
+          artifacts: build/nvda/HISS-${{ steps.tagName.outputs.tag }}.zip, build/nvda/HISS-${{ steps.tagName.outputs.tag }}.nvda-addon, HISS-${{ steps.tagName.outputs.tag }}_info.json
           draft: true
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+build/
+version.json

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 build/
-version.json
+*.json
+*.zip

--- a/make_version_info.py
+++ b/make_version_info.py
@@ -1,0 +1,44 @@
+# make version info json
+
+import hashlib
+import json
+
+
+def getVersion():
+    with open("version.json", "r", encoding="UTF-8") as f:
+        v = json.load(f)
+    return v
+
+
+def calcPackageHash(versionobject):
+    h = hashlib.sha1()
+    path = "build\\nvda\\HISS-%s.zip" % versionobject["version"]
+    with open(path, "rb") as f:
+        h.update(f.read())
+    return h.hexdigest()
+
+
+def calcPatchHash(versionobject):
+    h = hashlib.sha1()
+    path = "build\\nvda\\HISS-%s.nvda-addon" % versionobject["version"]
+    with open(path, "rb") as f:
+        h.update(f.read())
+    return h.hexdigest()
+
+
+def save(jsonname, versionobject, packagehash, patchhash):
+    newjson = {
+        "version": versionobject["version"],
+        "release_date": versionobject["release_date"],
+        "package_hash": packagehash,
+        "patch_hash": patchhash
+    }
+    with open(jsonname, "w", encoding="UTF-8") as f:
+        json.dump(newjson, f)
+
+
+versionobject = getVersion()
+jsonname = "HISS-%s_info.json" % versionobject["version"]
+packagehash = calcPackageHash(versionobject)
+patchhash = calcPatchHash(versionobject)
+save(jsonname, versionobject, packagehash, patchhash)


### PR DESCRIPTION
アップデート情報を作るスクリプトを追加
テストに使うファイルをgitignoreに登録
workflowでアップデート情報生成スクリプトをたたくようにした
本体、パッチ、バージョンアップ情報をリリスに含めるようにした