### PR TITLE
autocrlfを無効にして、改行コードを勝手に変換されないようにする

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,6 +13,8 @@ jobs:
         arch:
           - amd64_x86
     steps:
+      - name: set git options
+        run: git config --system core.autocrlf false
       - name: Get version
         uses: olegtarasov/get-tag@v2.1
         id: tagName


### PR DESCRIPTION
なんで1.0.0のときは発生してなかったのかなぞ。